### PR TITLE
Introduce function returning mac size of AEAD mode

### DIFF
--- a/evercrypt-rs/src/aead.rs
+++ b/evercrypt-rs/src/aead.rs
@@ -107,6 +107,7 @@ impl From<Mode> for Spec_Agile_AEAD_alg {
     }
 }
 
+/// Get the key size of the `Mode` in bytes.
 pub fn key_size(mode: &Mode) -> usize {
     match mode {
         Mode::Aes128Gcm => 16,
@@ -115,7 +116,8 @@ pub fn key_size(mode: &Mode) -> usize {
     }
 }
 
-pub fn mac_size(mode: &Mode) -> usize {
+/// Get the tag size of the `Mode` in bytes.
+pub fn tag_size(mode: &Mode) -> usize {
     match mode {
         Mode::Aes128Gcm => 16,
         Mode::Aes256Gcm => 16,

--- a/evercrypt-rs/src/aead.rs
+++ b/evercrypt-rs/src/aead.rs
@@ -115,6 +115,14 @@ pub fn key_size(mode: &Mode) -> usize {
     }
 }
 
+pub fn mac_size(mode: &Mode) -> usize {
+    match mode {
+        Mode::Aes128Gcm => 16,
+        Mode::Aes256Gcm => 16,
+        Mode::Chacha20Poly1305 => 16,
+    }
+}
+
 #[derive(Debug, PartialEq)]
 pub enum Error {
     InvalidInit = 0,

--- a/evercrypt-rs/src/prelude.rs
+++ b/evercrypt-rs/src/prelude.rs
@@ -3,8 +3,8 @@
 
 pub use crate::aead::{
     decrypt as aead_decrypt, encrypt as aead_encrypt, key_gen as aead_key_gen,
-    key_size as aead_key_size, nonce_gen as aead_nonce_gen, Aead, Error as AeadError,
-    Mode as AeadMode,
+    key_size as aead_key_size, nonce_gen as aead_nonce_gen, tag_size as aead_tag_size, Aead,
+    Error as AeadError, Mode as AeadMode,
 };
 pub use crate::digest::{get_digest_size, hash, Digest, Error as DigestError, Mode as DigestMode};
 pub use crate::ecdh::{


### PR DESCRIPTION
Similar to the existing `key_size` function, this PR introduces `mac_size` function that returns the size of the MAC tag given an AEAD mode.