### PR TITLE
Bump version

### DIFF
--- a/evercrypt-rs/Cargo.toml
+++ b/evercrypt-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evercrypt"
-version = "0.0.7"
+version = "0.0.8"
 authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
 edition = "2018"
 license = "MPL-2.0"
@@ -22,7 +22,7 @@ random = ["rand", "rand_core"]
 serialization = ["serde", "serde_json"]
 
 [dependencies]
-evercrypt-sys = { version = "0.0.6" }
+evercrypt-sys = { version = "0.0.7" }
 aes-gcm = { version = "0.8", optional = true }
 rand = { version = "0.7", optional = true }
 rand_core = { version = "0.5", optional = true }

--- a/evercrypt-sys/Cargo.toml
+++ b/evercrypt-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "evercrypt-sys"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Franziskus Kiefer <franziskuskiefer@gmail.com>"]
 edition = "2018"
 build = "build.rs"


### PR DESCRIPTION
Bumping the version so that `hpke-rs` and `OpenMLS` can pull it in.

@franziskuskiefer could you also publish on `crates.io`?