### PR TITLE
Fix building without the feature "random" enabled

### DIFF
--- a/.github/workflows/evercrypt-rs.yml
+++ b/.github/workflows/evercrypt-rs.yml
@@ -38,6 +38,10 @@ jobs:
         run: |
           cd evercrypt-rs
           cargo test --verbose
+      - name: Build (no-default-features)
+        run: |
+          cd evercrypt-rs
+          cargo build --verbose --no-default-features
       - if: matrix.os == 'ubuntu-latest'
         name: Build & Test 32-bit Linux
         run: |

--- a/evercrypt-rs/src/p256.rs
+++ b/evercrypt-rs/src/p256.rs
@@ -248,11 +248,13 @@ pub fn ecdsa_verify(
     }
 }
 
+#[cfg(feature = "random")]
 /// Generate a random nonce for ECDSA.
 pub fn random_nonce() -> Nonce {
     crate::rand_util::get_random_array()
 }
 
+#[cfg(feature = "random")]
 /// Generate a new P256 scalar (private key).
 pub fn key_gen() -> Scalar {
     loop {

--- a/evercrypt-rs/src/prelude.rs
+++ b/evercrypt-rs/src/prelude.rs
@@ -2,34 +2,38 @@
 //! Include this to get access to all the public functions of Evercrypt.
 
 pub use crate::aead::{
-    decrypt as aead_decrypt, encrypt as aead_encrypt, key_gen as aead_key_gen,
-    key_size as aead_key_size, nonce_gen as aead_nonce_gen, tag_size as aead_tag_size, Aead,
-    Error as AeadError, Mode as AeadMode,
+    decrypt as aead_decrypt, encrypt as aead_encrypt, key_size as aead_key_size,
+    tag_size as aead_tag_size, Aead, Error as AeadError, Mode as AeadMode,
 };
 pub use crate::digest::{get_digest_size, hash, Digest, Error as DigestError, Mode as DigestMode};
 pub use crate::ecdh::{
-    self, derive as ecdh_derive, derive_base as ecdh_derive_base, key_gen as ecdh_key_gen,
-    Error as EcdhError, Mode as EcdhMode,
+    self, derive as ecdh_derive, derive_base as ecdh_derive_base, Error as EcdhError,
+    Mode as EcdhMode,
 };
 pub use crate::ed25519::{
-    self, eddsa_sign as ed25519_sign, eddsa_verify as ed25519_verify, key_gen as ed25519_key_gen,
-    sk2pk as ed25519_sk2pk, Error as Ed25519Error, Point as Ed25519Point, Scalar as Ed25519Scalar,
+    self, eddsa_sign as ed25519_sign, eddsa_verify as ed25519_verify, sk2pk as ed25519_sk2pk,
+    Error as Ed25519Error, Point as Ed25519Point, Scalar as Ed25519Scalar,
     Signature as Ed25519Signature,
 };
 pub use crate::hkdf::{self, expand as hkdf_expand, extract as hkdf_extract, hkdf};
 pub use crate::hmac::{get_tag_size, hmac, Mode as HmacMode};
 pub use crate::p256::{
     self, dh as p256, dh_base as p256_base, ecdsa_sign as p256_sign, ecdsa_verify as p256_verify,
-    random_nonce as p256_ecdsa_random_nonce, validate_pk as p256_validate_pk,
-    validate_sk as p256_validate_sk, Error as P256Error, Nonce as P256Nonce, Scalar as P256Scalar,
-    Signature as EcdsaSignature,
+    validate_pk as p256_validate_pk, validate_sk as p256_validate_sk, Error as P256Error,
+    Nonce as P256Nonce, Scalar as P256Scalar, Signature as EcdsaSignature,
 };
-pub use crate::rand_util::{get_random_array, get_random_vec};
-pub use crate::signature::{
-    self, key_gen as signature_key_gen, sign, verify, Error as SignatureError,
-    Mode as SignatureMode,
-};
+pub use crate::signature::{self, sign, verify, Error as SignatureError, Mode as SignatureMode};
 pub use crate::x25519::{
-    self, dh as x25519, dh_base as x25519_base, key_gen as x25519_key_gen, Error as X25519Error,
-    Point as X25519Point, Scalar as X25519Scalar,
+    self, dh as x25519, dh_base as x25519_base, Error as X25519Error, Point as X25519Point,
+    Scalar as X25519Scalar,
+};
+#[cfg(feature = "random")]
+pub use crate::{
+    aead::{key_gen as aead_key_gen, nonce_gen as aead_nonce_gen},
+    ecdh::key_gen as ecdh_key_gen,
+    ed25519::key_gen as ed25519_key_gen,
+    p256::random_nonce as p256_ecdsa_random_nonce,
+    rand_util::{get_random_array, get_random_vec},
+    signature::key_gen as signature_key_gen,
+    x25519::key_gen as x25519_key_gen,
 };

--- a/evercrypt-rs/src/signature.rs
+++ b/evercrypt-rs/src/signature.rs
@@ -21,6 +21,7 @@ pub enum Mode {
     P256,
 }
 
+#[cfg(feature = "random")]
 /// Generate a new key pair for the given `mode`.
 pub fn key_gen(mode: Mode) -> Result<(Vec<u8>, Vec<u8>), Error> {
     match mode {


### PR DESCRIPTION
Right now evercrypt-rs does not build without "random" being enabled. This PR fixes this issue.